### PR TITLE
team blog update

### DIFF
--- a/teamBlogs/index.md
+++ b/teamBlogs/index.md
@@ -1,0 +1,39 @@
+# Team Blogs
+<br>
+
+## [254 The Cheesy Poofs](https://www.thebluealliance.com/team/254)
+<br>
+
+- [254](https://www.team254.com/blog/)
+
+<br>
+
+***
+<br>
+
+## [3847 Spectrum  -△◅](https://www.thebluealliance.com/team/3847)
+<br>
+
+- [3847 Spectrum](http://blog.spectrum3847.org/)
+<br>
+
+### OA Blogs
+<br>
+
+- [2022: Spectrum 3847 | Build Blog](https://www.chiefdelphi.com/t/spectrum-3847-build-blog-2022/399190?u=jimmyy)
+- [2023: Spectrum 3847 | Build Blog](https://www.chiefdelphi.com/t/spectrum-3847-build-blog-2023/420801?u=jimmyy)
+
+
+<br>
+
+***
+<br>
+
+## [4911 CyberKnights](https://www.thebluealliance.com/team/4911)
+<br>
+
+- [4911 CyberKnights](https://daswulfkrallebots.blogspot.com/)
+<br>
+
+***
+<br>


### PR DESCRIPTION
added the 
# Team Blog section
added: 
- [254](https://www.team254.com/blog/)
- [3847 Spectrum](http://blog.spectrum3847.org/)
- [2022: Spectrum 3847 | Build Blog](https://www.chiefdelphi.com/t/spectrum-3847-build-blog-2022/399190?u=jimmyy)
- [2023: Spectrum 3847 | Build Blog](https://www.chiefdelphi.com/t/spectrum-3847-build-blog-2023/420801?u=jimmyy)
- [4911 CyberKnights](https://daswulfkrallebots.blogspot.com/)